### PR TITLE
Improve examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![npm version](https://img.shields.io/npm/v/visstr.svg?sanitize=true)](https://www.npmjs.com/package/visstr)
 
-
 # VisStr
 
 VisStr is a library to visualize a string and its properties such as repetitions, occurrences, and redundancies.
@@ -10,48 +9,6 @@ The following image visualizes all palindromes that occurs as substrings in "mis
 ![](others/palindromes.png)
 
 See [demos](https://kg86.github.io/visstr/dist/vis_str_demo.html) and [API documents](https://kg86.github.io/visstr/docs/index.html).
-
-## Usage
-
-Put a canvas in your html, and then import `vis_str.js` like the following.
-(`vis_str.js` is output to `./bundles` by compile.)
-```html
-<canvas id="canvas" style="border:1px solid #000000;"> </canvas>
-<script type="text/javascript" src="./vis_str.js"></script>
-```
-
-Create an visstr object in your js.
-```js
-const visstr = window.visstr
-
-const canvas = document.querySelector('#canvas')
-// input string
-const s = 'abaababaabaab'
-// create visstr object.
-const vstr = new visstr.VisStr(canvas)
-```
-
-Create a range list you want to draw, and add line style and color, and then group them so that they do not overlap with each other.
-```js
-// create occurrences of aba.
-const occ_aba = [[0, 2], [3, 5], [5, 7], [8, 10]]
-// add line style and color.
-const ranges = vstr.makeRanges(occ_aba, 'arrow', '#ff0000')
-// make group so that they are not overlap with each others.
-const range_groups = vstr.nonOverlapRanges(ranges)
-```
-
-Draw the range list by `vstr.draw`.
-```js
-// draw the occurrences.
-vstr.draw(s, range_groups)
-```
-
-The canvas draws the range list as following.
-
-![](others/occ_aba.png)
-
-See [the demo](https://kg86.github.io/visstr/dist/vis_str_demo_occ.html).
 
 ## Compile
 
@@ -64,4 +21,52 @@ $ npm install
 $ npm run build
 ```
 
-Libraries are output in `./lib`.
+Libraries are output in `./lib` (UMD/CommonJS) and demo assets in `./dist`.
+
+## Examples: Visualizing the substring occurrences
+
+This is an example to visualize all the occurrences of `aba` in `abaababaabaab` using VisStr.
+
+1. Add `<canvas>` element to the HTML which is a core of the visualizer.
+
+```html
+<canvas id="canvas" width="1000" height="240" style="border:1px solid #000000;">
+</canvas>
+```
+
+2. Load the VisStr library `../lib/vis_str.umd.js`.
+   Note that we have to use umd version for browser.
+
+```html
+<script type="text/javascript" src="../lib/vis_str.umd.js"></script>
+```
+
+3. Create a string and a range list representing the occurrences of `aba`, and specify the style of the range list (e.g., arrow, line, curve) and the color.
+
+```javascript
+const { VisStr } = window.visstr;
+const canvas = document.querySelector("#canvas");
+// create visstr object.
+const vstr = new VisStr(canvas);
+// input string
+const s = "abaababaabaab";
+
+// create occurrences of aba.
+const occAba = [
+  [0, 2],
+  [3, 5],
+  [5, 7],
+  [8, 10],
+];
+// add line style and color.
+const ranges = vstr.makeRanges(occAba, "arrow", "#ff0000");
+// make group so that they are not overlap with each others.
+const grouped = vstr.nonOverlapRanges(ranges);
+vstr.draw(s, grouped);
+```
+
+The result is visualized as follows:
+
+![](others/occ_aba.png)
+
+You can find the [source code](dist/vis_str_demo_occ.html), and the [demo page](https://kg86.github.io/visstr/dist/vis_str_demo_occ.html).

--- a/dist/vis_str_demo_occ.html
+++ b/dist/vis_str_demo_occ.html
@@ -1,28 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-1745272-7"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-1745272-7');
-    </script>
+    <meta charset="UTF-8" />
+    <title>Occurrences of "aba"</title>
   </head>
-  <body style="text-align: center; font-size: 18px">
+  <body>
     <h2>Occurrences of "aba".</h2>
-
-    <canvas id="canvas" style="border: 1px solid #000000"></canvas>
+    <canvas
+      id="canvas"
+      width="1000"
+      height="240"
+      style="border:1px solid #000000;"
+    >
+    </canvas>
     <script type="text/javascript" src="../lib/vis_str.umd.js"></script>
-    <script type="text/javascript">
-      const visstr = window.visstr
-
+    <script>
+      const { VisStr } = window.visstr
       const canvas = document.querySelector('#canvas')
+      // create visstr object.
+      const vstr = new VisStr(canvas)
       // input string
       const s = 'abaababaabaab'
-      // create visstr object.
-      const vstr = new visstr.VisStr(canvas)
+
       // create occurrences of aba.
       const occ_aba = [
         [0, 2],
@@ -33,34 +32,8 @@
       // add line style and color.
       const ranges = vstr.makeRanges(occ_aba, 'arrow', '#ff0000')
       // make group so that they are not overlap with each others.
-      const range_groups = vstr.nonOverlapRanges(ranges)
-      // draw the occurrences.
-      vstr.draw(s, range_groups)
+      const grouped = vstr.nonOverlapRanges(ranges)
+      vstr.draw(s, grouped)
     </script>
-    <br />
-
-    The figure of the above is drawn by the following source code.<br />
-    The original code is
-    <a href="https://github.com/kg86/visstr/dist/vis_str_demo_occ.html">here</a
-    >.<br />
-    See also
-    <a href="https://github.com/kg86/visstr">the visstr repository</a>.
-    <pre style="width: 500px; text-align: left; margin: auto">
-const visstr = window.visstr
-
-const canvas = document.querySelector('#canvas')
-// input string
-const s = 'abaababaabaab'
-// create visstr object.
-const vstr = new visstr.VisStr(canvas)
-// create occurrences of aba.
-const occ_aba = [[0, 2], [3, 5], [5, 7], [8, 10]]
-// add line style and color.
-const ranges = vstr.makeRanges(occ_aba, 'arrow', '#ff0000')
-// make group so that they are not overlap with each others.
-const range_groups = vstr.nonOverlapRanges(ranges)
-// draw the occurrences.
-vstr.draw(s, range_groups)
-    </pre>
   </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reworks README with compile instructions and a clearer step-by-step occurrence example, and updates the demo HTML to a simplified UMD-based version.
> 
> - **Docs (README)**:
>   - Add **Compile** section with build steps; clarify outputs to `./lib` (UMD/CommonJS) and `./dist`.
>   - Replace/expand usage with a step-by-step example visualizing `aba` occurrences, including explicit `<canvas>` sizing, loading `../lib/vis_str.umd.js`, and modern code (`const { VisStr } = window.visstr`, `nonOverlapRanges`, `draw`).
>   - Link to example source `dist/vis_str_demo_occ.html` and demo page.
> - **Demo**:
>   - Update `dist/vis_str_demo_occ.html` to a minimal page: add charset/title, set canvas width/height, use UMD `../lib/vis_str.umd.js`, instantiate via `new VisStr`, and render grouped ranges.
>   - Remove Google Analytics and extraneous explanatory markup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f2b2cbe376c6f2daabe7aa9b81cac230db6c32b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->